### PR TITLE
Update gen_con_spec_lib.py

### DIFF
--- a/MSFragger-GUI/tools/speclib/gen_con_spec_lib.py
+++ b/MSFragger-GUI/tools/speclib/gen_con_spec_lib.py
@@ -761,7 +761,7 @@ def main_easypqp():
 	output_directory = workdir / 'easypqp_files'
 	output_directory.mkdir(exist_ok=overwrite)
 	if irt_choice is Irt_choice.iRT:
-		irt_df.to_csv(irt_file, index=False, sep='\t', line_terminator='\n')
+		irt_df.to_csv(irt_file, index=False, sep='\t', lineterminator='\n')
 	elif irt_choice is Irt_choice.ciRT:
 		shutil.copyfile(script_dir / 'hela_irtkit.tsv', irt_file)
 	elif irt_choice is Irt_choice.Pierce_iRT:


### PR DESCRIPTION
The "to_csv()" method of a pandas frame does not have a parameter called "line_terminator" as used in the function "main_easypqp", line 765. It should be "lineterminator". For references, you can check https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html