### PR TITLE
Allow underlying non-zero exit codes to bubble up

### DIFF
--- a/MSFragger-GUI/src/com/dmtavt/fragpipe/cmd/ProcessBuilderInfo.java
+++ b/MSFragger-GUI/src/com/dmtavt/fragpipe/cmd/ProcessBuilderInfo.java
@@ -158,6 +158,11 @@ public class ProcessBuilderInfo {
         toConsole(Fragpipe.COLOR_RED_DARKEST, msg, true, console);
         // all the cleanup is done in the final block
       } finally {
+        // grab the exit code of the process to use for System.exit() if operating in headless mode
+        int overallExitCode = 0;
+        if (started != null && started.exitValue() != 0) {
+          overallExitCode = started.exitValue();
+        }
         // in the end whatever happens always try to kill the process
         if (started != null && started.isAlive()) {
           log.debug("Killing underlying external process");
@@ -167,6 +172,9 @@ public class ProcessBuilderInfo {
           pr.close();
         } catch (Exception e) {
           log.error("Error closing redirected std/err streams from external process", e);
+        }
+        if (Fragpipe.headless && overallExitCode != 0) {
+          System.exit(overallExitCode);
         }
       }
     };


### PR DESCRIPTION
Firstly, congratulations 🎉 on providing `--headless` mode! Since we last developed FragPipe workflows (v14.0) the introduction of this mode has allowed us to proceed with Ubuntu containerization and stable batch-style job automation. It's made all the difference… 🙏

One issue we noticed however, was that non-zero exit codes returned from any of the given tasks were masked by a zero exit code from the `./fragpipe` command itself. This would result in false positives being returned to our orchestration scripts, preventing us from detecting and responding to execution issues. An edited log from a contrived example:
```
root@d4caeabf7c84:/usr/src# ./fragpipe --headless --workflow /root/experiment/NDDCelu0530t/aspree-standard-fragpipe-md5-a10d8beb46841e0e6553441e42caf1df.workflow --manifest /root/experiment/NDDCelu0530t/IPA_17_4_1_35289.fp-manifest --workdir /root/experiment/NDDCelu0530t/fragpipe-output --config-msfragger /MSFragger-3.8/MSFragger-3.8.jar --config-ionquant /IonQuant-1.9.8/IonQuant-1.9.8.jar --config-philosopher /philosopher --config-python /usr/bin/python3
…
Version info:
FragPipe version 20.0
MSFragger version 3.8
IonQuant version 1.9.8/IonQuant-1.9.8
Philosopher version 5.0.0
…
add_W_tryptophan = 0.0
add_X_user_amino_acid = 0.0
add_Y_tyrosine = 0.0
add_Z_user_amino_acid = 0.0
Insufficient memory!
Process 'MSFragger' finished, exit code: 1
Process returned non-zero exit code, stopping

~~~~~~~~~~~~~~~~~~~~
Cancelling 13 remaining tasks
root@d4caeabf7c84:/usr/src# echo $?
0
```

With the change presented in this PR, the non-zero exit codes are allowed to bubble up. We rebuilt the project with this change in place locally and created a v20.1 to demonstrate the effect:
```
root@186fa93fc96c:/usr/src# ./fragpipe --headless --workflow /root/experiment/NDDCelu0530t/aspree-standard-fragpipe-md5-a10d8beb46841e0e6553441e42caf1df.workflow --manifest /root/experiment/NDDCelu0530t/IPA_17_4_1_35289.fp-manifest --workdir /root/experiment/NDDCelu0530t/fragpipe-output --config-msfragger /MSFragger-3.8/MSFragger-3.8.jar --config-ionquant /IonQuant-1.9.8/IonQuant-1.9.8.jar --config-philosopher /philosopher --config-python /usr/bin/python3 
…
Version info:
FragPipe version 20.1
MSFragger version 3.8
IonQuant version 1.9.8/IonQuant-1.9.8
Philosopher version 5.0.0
…
add_W_tryptophan = 0.0
add_X_user_amino_acid = 0.0
add_Y_tyrosine = 0.0
add_Z_user_amino_acid = 0.0
Insufficient memory!
Process 'MSFragger' finished, exit code: 1
Process returned non-zero exit code, stopping

~~~~~~~~~~~~~~~~~~~~
Cancelling 13 remaining tasks
root@186fa93fc96c:/usr/src# echo $?
1
```

This doesn't constitute broad testing, but hopefully it serves to provide the basis of a suitable change. Look forward to your thoughts!