### PR TITLE
fix #1940, remove copying the tools directory twice

### DIFF
--- a/MSFragger-GUI/build.gradle
+++ b/MSFragger-GUI/build.gradle
@@ -82,9 +82,6 @@ distributions {
         distributionBaseName = "${project.name}-${project.version}"
         contents {
             from('/') {
-                include 'tools/**'
-            }
-            from('/') {
                 include 'workflows/**'
             }
         }


### PR DESCRIPTION
Affects Windows but not Linux